### PR TITLE
Add GitHub Actions workflow to extract and update English menu strings in en.yml

### DIFF
--- a/.github/workflows/exctarct-en-lang.yml
+++ b/.github/workflows/exctarct-en-lang.yml
@@ -1,0 +1,60 @@
+name: Extract menu strings to en.yml
+
+on:
+  push:
+    paths:
+      - 'mkdocs.yml'
+
+jobs:
+  update-en-yml:
+    name: Process changes in English menu items
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.check_changes.outputs.has_changes }}
+    env:
+      MKDOCS_FILE: "mkdocs.yml"
+      TARGET_FILE: "./docs/en/en.yml"
+      TMP_FILE: "$(mktemp)"
+
+    steps:
+      - name: ⬇️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🧰 Set up yq
+        uses: mikefarah/yq@v4
+
+      - name: 📝 Update en.yml
+        run: |
+          yq eval '(.plugins[].i18n.languages[] | select(.locale == "en")) | del(.default)' "$MKDOCS_FILE" > "$TMP_FILE"
+
+          yq eval --inplace "
+            (.en.plugins[].i18n.languages[] | select(.locale == \"en\")) = load (\"$TMP_FILE\")
+          " "$TARGET_FILE"
+
+          rm "$TMP_FILE"
+
+      - name: Check if something has been changed in en.yaml
+        id: check_changes
+        run: |
+          git update-index --refresh
+          if git diff-index --quiet HEAD -- "${TARGET_FILE}"; then
+            echo "No changes detected"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "Detected changes in en.yml"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "${TARGET_FILE}"
+          git commit -m "Changes in ${TARGET_FILE}"
+          git push
+
+      - name: No changes detected
+        if: steps.check_changes.outputs.has_changes == 'false'
+        run: |
+          echo "No changes to commit."

--- a/docs/en/en.yml
+++ b/docs/en/en.yml
@@ -2,17 +2,19 @@ en:
   plugins:
     - i18n:
         languages:
-          # ISO code of your language 
-          - locale: en
+          - # ISO code of your language
+            locale: en
             # Name of your languge
             name: English
             # Day/Night toggle
             theme:
               palette:
                 - toggle:
+                    name: Switch to light mode
+                - toggle:
                     name: Switch to dark mode
                 - toggle:
-                    name: Switch to light mode
+                    name: Switch to system preference
             # Translate copyright statement
             copyright: © 2013–2023 OpenStreetMap and contributors, <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/2.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>.
             nav_translations:

--- a/docs/uk/uk.yml
+++ b/docs/uk/uk.yml
@@ -2,24 +2,26 @@ uk:
   plugins:
     - i18n:
         languages:
-          # ISO code of your language 
-          - locale: uk
+          - # ISO code of your language
+            locale: uk
             # Name of your languge
             name: Українська
             # Day/Night toggle
             theme:
               palette:
                 - toggle:
+                    name: Увімкнути світлий режим
+                - toggle:
                     name: Увімкнути темний режим
                 - toggle:
-                    name: Увімкнути світлий режим
+                    name: Увімкнути режим системи
             # Translate copyright statement
             copyright: "© 2013–2023 Учасники OpenStreetMap, <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-sa/2.0/80x15.png\" /></a><br />Матеріали цього сайту ліцензуються на умовах Ліцензії – <a rel=\"license\" href=\"https://creativecommons.org/licenses/by-sa/2.0/deed.uk\" target=\"_blank\">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>."
             nav_translations:
               # Menu item name for the /index.md
               Home: Switch2OSM
               # Menu item name for the /why-switch.md
-              Why: "Навіщо?"
+              Why: Навіщо?
               # Menu item name for the /case-studies.md
               Cases: Вже з OSM
               # Menu item name for the /the-basics.md

--- a/docs/zh-TW/zh-TW.yml
+++ b/docs/zh-TW/zh-TW.yml
@@ -2,17 +2,19 @@ zh_TW:
   plugins:
     - i18n:
         languages:
-          # ISO code of your language 
-          - locale: zh-TW
+          - # ISO code of your language
+            locale: zh-TW
             # Name of your languge
             name: 台灣華語
             # Day/Night toggle
             theme:
               palette:
                 - toggle:
+                  name: 切換到燈光模式
+                - toggle:
                     name: 切換到深色模式
                 - toggle:
-                    name: 切換到燈光模式
+                    name: 切換到系統偏好設定
             # Translate copyright statement
             copyright: "© 2013–2023 開放街圖與貢獻者。 <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-sa/2.0/\" target=\"_blank\"><img alt=\"Creative Commons License\" style=\"border-width:0\" src=\"https://i.creativecommons.org/l/by-sa/2.0/80x15.png\" /></a><br />這些資料採用 <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-sa/2.0/\" target=\"_blank\">創用CC相同方式分享 2.0 未本地化授權條款</a>。"
             nav_translations:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -139,25 +139,25 @@ nav:
 
 plugins:
   - search:
-      lang:
-        - en
-        - uk
-        - zh-TW
+      lang: [en, uk, zh-TW]
   - macros
   - ezlinks
   - glightbox
   - section-index
 
-# This part is for organising languages in specific folders
-# Using a folder per language structure
-# https://ultrabug.github.io/mkdocs-static-i18n/
+  # This part is for organising languages in specific folders
+  # Using a folder per language structure
+  # https://ultrabug.github.io/mkdocs-static-i18n/
   - i18n:
       docs_structure: folder
       reconfigure_material: true
       languages:
-        - locale: en
+        - # ISO code of your language
+          locale: en
+          # Name of your languge
           name: English
           default: true
+          # Day/Night toggle
           theme:
             palette:
               - toggle:
@@ -166,28 +166,46 @@ plugins:
                   name: Switch to dark mode
               - toggle:
                   name: Switch to system preference
+          # Translate copyright statement
           copyright: © 2013–2023 OpenStreetMap and contributors, <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/2.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/2.0/" target="_blank">Creative Commons Attribution-ShareAlike 2.0 Generic License</a>.
           nav_translations:
+            # Menu item name for the /index.md
             Home: Switch2OSM
+            # Menu item name for the /why-switch.md
             Why: Why Switch?
+            # Menu item name for the /case-studies.md
             Cases: Case Studies
+            # Menu item name for the /the-basics.md
             Basics: The Basics
+            # Menu item name for the "Using Tiles" tab
             Using: Using Tiles
-            # Own tiles: Switch to using OSM tiles
+            # Menu item name for the side menu
             Leaflet: Getting started with Leaflet
+            # Menu item name for the side menu
             OpenLayers: Getting started with OpenLayers
+            # Menu item name for the side menu
             Vector Tiles: Power of Vector Map Tiles
+            # Menu item name for the "Serving Tiles" tab
             Serving: Serving Tiles
-            # Serving tiles: Serving your own tiles
+            # Serving tiles: Manually building a tile server
             Manually: Manually building a tile server
+            # Serving tiles: Using a Docker container
             Docker: Using a Docker container
+            # Serving tiles: Monitoring using Munin
             Munin: Monitoring using Munin
+            # Serving tiles: Updating your database as people edit OpenStreetMap
             Updating: Updating your database as people edit OpenStreetMap
+            # Serving tiles: Vector Map Tiles
             Serving vector tiles: Vector Map Tiles
+            # Vector Map Tiles: Steps to Serve Vector Map Tiles
             Steps: General steps
+            # Vector Map Tiles: Getting started with TileServer GL
             TileServer GL: Getting started with TileServer GL
+            # Menu item name for the /other-uses.md
             Other: Other Uses
+            # Menu item name for the /providers.md
             Providers: Providers
+            # Menu item name for the /find-out-more.md
             More: Getting help
         - locale: uk
           name: Українська


### PR DESCRIPTION
Closes: #66

This PR introduces a new workflow for updating the `docs/en/en.yml` file with the changes that have occurred in `mkdocs.yml`, which is then used in Transifex to localise menu items.

Also, along with this workflow, comments were added to `mkdocs.yml` to explain which menu item is associated with the corresponding line in the file.

The `docs/*/*.yml` files themselves have also been updated with the latest changes from `mkdocs.yml`.